### PR TITLE
Throttle drawing-data emissions in play.js

### DIFF
--- a/client/src/pages/play.js
+++ b/client/src/pages/play.js
@@ -83,13 +83,18 @@ const Play = () => {
   };
 
   // Emit drawing updates only if you're the drawer
+  const lastEmit = useRef(0);
   const handleCanvasChange = (paths) => {
     if (isDrawer) {
-      socket.emit("drawing-data", {
-        gameId: roomId,
-        userId: getUserId(),
-        data: paths,
-      });
+      const now = Date.now();
+      if (now - lastEmit.current > 100) { // Throttle emits to every 100ms
+        socket.emit("drawing-data", {
+          gameId: roomId,
+          userId: sessionStorage.getItem("userId"),
+          data: paths,
+        });
+        lastEmit.current = now;
+      }
     }
   };
 


### PR DESCRIPTION
Throttle drawing data emissions to every 100ms for performance.