### PR TITLE
Fixed: Different scores in leaderboard

### DIFF
--- a/client/src/pages/play.js
+++ b/client/src/pages/play.js
@@ -436,7 +436,7 @@ const Play = () => {
       });
     });
 
-    socket.on("gameEnded", () => {
+    socket.on("gameEnded", (data) => {
       setRoundResult({ type: "gameEnded" });
       const base = Array.isArray(playersRef.current)
         ? playersRef.current
@@ -444,7 +444,7 @@ const Play = () => {
 
       const currentProfiles = profilesRef.current;
 
-      const withAvatars = base.map((p) => {
+      const withAvatars = data.finalPlayers.map((p) => {
         const prof = currentProfiles[p.userId] || {};
         const seed = prof.avatarSeed || p.displayName || p.userId || "player";
         const style = prof.avatarStyle || "funEmoji";

--- a/server/game/gameSessionManager.js
+++ b/server/game/gameSessionManager.js
@@ -210,24 +210,19 @@ class GameSessionManager {
     });
   }
 
-  nextRound(gameId, io) {
+  nextRound(gameId) {
     const session = this.sessions.get(gameId);
     if (!session) return null;
 
     const lastDrawer = session.players[session.currentPlayerIndex];
 
-    // End game when if reached total rounds and last drawer was Blue team
+    // No next round if reached total rounds and last drawer was Blue team
     if (lastDrawer.team === "Blue" && session.currentRound >= session.totalRounds) {
-      // Sync final scores before game ends
-      io.to(gameId).emit("updatePlayers", this.getPlayersWithScores(gameId));
-      console.log(`GameEnd score synced`);
       return null;
     }
 
     // Round number only increments after Blue team's turn, as Red always starts first
     if (lastDrawer.team === "Blue") {
-      // Sync final scores before next round starts
-      io.to(gameId).emit("updatePlayers", this.getPlayersWithScores(gameId));
       console.log(`RoundEnd score synced`);
       session.currentRound++;
     }

--- a/server/game/gameSessionManager.js
+++ b/server/game/gameSessionManager.js
@@ -210,18 +210,25 @@ class GameSessionManager {
     });
   }
 
-  nextRound(gameId) {
+  nextRound(gameId, io) {
     const session = this.sessions.get(gameId);
     if (!session) return null;
 
     const lastDrawer = session.players[session.currentPlayerIndex];
 
     // End game when if reached total rounds and last drawer was Blue team
-    if (lastDrawer.team === "Blue" 
-        && session.currentRound >= session.totalRounds) return null;
+    if (lastDrawer.team === "Blue" && session.currentRound >= session.totalRounds) {
+      // Sync final scores before game ends
+      io.to(gameId).emit("updatePlayers", this.getPlayersWithScores(gameId));
+      console.log(`GameEnd score synced`);
+      return null;
+    }
 
     // Round number only increments after Blue team's turn, as Red always starts first
     if (lastDrawer.team === "Blue") {
+      // Sync final scores before next round starts
+      io.to(gameId).emit("updatePlayers", this.getPlayersWithScores(gameId));
+      console.log(`RoundEnd score synced`);
       session.currentRound++;
     }
 

--- a/server/game/gameSessionManager.js
+++ b/server/game/gameSessionManager.js
@@ -217,13 +217,11 @@ class GameSessionManager {
     const lastDrawer = session.players[session.currentPlayerIndex];
 
     // No next round if reached total rounds and last drawer was Blue team
-    if (lastDrawer.team === "Blue" && session.currentRound >= session.totalRounds) {
-      return null;
-    }
+    if (lastDrawer.team === "Blue" 
+        && session.currentRound >= session.totalRounds) return null;
 
     // Round number only increments after Blue team's turn, as Red always starts first
     if (lastDrawer.team === "Blue") {
-      console.log(`RoundEnd score synced`);
       session.currentRound++;
     }
 

--- a/server/game/gameSocket.js
+++ b/server/game/gameSocket.js
@@ -388,27 +388,24 @@ function proceedToNextRound(io, gameId) {
 
     const nextRoundInfo = gameSessionManager.nextRound(gameId);
 
-    // YUE
-    // 2. 获取当前服务器内存中最新、最全的分数列表
-    const finalPlayers = gameSessionManager.getPlayersWithScores(gameId);
+    // Get latest scores before starting the next round
+    const finalPlayersWithScore = gameSessionManager.getPlayersWithScores(gameId);
 
     if (nextRoundInfo) {
-      // --- 情况 A: 还有下一轮 ---
-      // 先强制同步一次分数，确保所有人在新回合开始前分数一致
-      io.to(gameId).emit("updatePlayers", finalPlayers);
+      // Sync scores before starting the next round
+      io.to(gameId).emit("updatePlayers", finalPlayersWithScore);
 
-      // startRound is responsible for: sending a new Flashcard to the questioner, broadcasting drawerChanged/roundStarted, and updating gameState
+      // startRound is responsible for: sending a new Flashcard to the questioner, 
+      // broadcasting drawerChanged/roundStarted, and updating gameState
       gameSessionManager.startRound(gameId, io);
 
       io.to(gameId).emit("startTimer", { duration: nextRoundInfo.timer });
       startSynchronizedTimer(io, gameId, nextRoundInfo.timer);
     } else {
-      // --- 情况 B: 游戏真正结束 ---
-      // 关键：先同步最后一次分数
-      io.to(gameId).emit("updatePlayers", finalPlayers);
+      // Sync scores before emitting gameEnded
+      io.to(gameId).emit("updatePlayers", finalPlayersWithScore);
       
-      // 关键：发出结束信号，并直接带上最终分数包
-      io.to(gameId).emit("gameEnded", { finalPlayers: finalPlayers });
+      io.to(gameId).emit("gameEnded", { finalPlayers: finalPlayersWithScore });
       clearActiveTimer(gameId);
     }
   } finally {

--- a/server/game/gameSocket.js
+++ b/server/game/gameSocket.js
@@ -386,7 +386,7 @@ function proceedToNextRound(io, gameId) {
     gameSessionManager.clearCanvasData(gameId);
     io.to(gameId).emit("clear-canvas");
 
-    const nextRoundInfo = gameSessionManager.nextRound(gameId);
+    const nextRoundInfo = gameSessionManager.nextRound(gameId, io);
 
     if (nextRoundInfo) {
       // startRound is responsible for: sending a new Flashcard to the questioner, broadcasting drawerChanged/roundStarted, and updating gameState

--- a/server/game/gameSocket.js
+++ b/server/game/gameSocket.js
@@ -386,16 +386,29 @@ function proceedToNextRound(io, gameId) {
     gameSessionManager.clearCanvasData(gameId);
     io.to(gameId).emit("clear-canvas");
 
-    const nextRoundInfo = gameSessionManager.nextRound(gameId, io);
+    const nextRoundInfo = gameSessionManager.nextRound(gameId);
+
+    // YUE
+    // 2. 获取当前服务器内存中最新、最全的分数列表
+    const finalPlayers = gameSessionManager.getPlayersWithScores(gameId);
 
     if (nextRoundInfo) {
+      // --- 情况 A: 还有下一轮 ---
+      // 先强制同步一次分数，确保所有人在新回合开始前分数一致
+      io.to(gameId).emit("updatePlayers", finalPlayers);
+
       // startRound is responsible for: sending a new Flashcard to the questioner, broadcasting drawerChanged/roundStarted, and updating gameState
       gameSessionManager.startRound(gameId, io);
 
       io.to(gameId).emit("startTimer", { duration: nextRoundInfo.timer });
       startSynchronizedTimer(io, gameId, nextRoundInfo.timer);
     } else {
-      io.to(gameId).emit("gameEnded");
+      // --- 情况 B: 游戏真正结束 ---
+      // 关键：先同步最后一次分数
+      io.to(gameId).emit("updatePlayers", finalPlayers);
+      
+      // 关键：发出结束信号，并直接带上最终分数包
+      io.to(gameId).emit("gameEnded", { finalPlayers: finalPlayers });
       clearActiveTimer(gameId);
     }
   } finally {


### PR DESCRIPTION
1. Sync scores before starting the next round and before emitting gameEnded in proceedToNextRound
2. Added getPlayersWithScores in gameEnded event
3. Use the scores from Step2 to render the final leaderboard