### PR TITLE
Updated logic of enter game with existing roomId

### DIFF
--- a/client/src/pages/lobby.js
+++ b/client/src/pages/lobby.js
@@ -240,11 +240,12 @@ const Lobby = () => {
       }, 1000);
     });
 
-    socket.on("gameEnded", () => {
-      toastSuccess("Game Over!");
-      setCurrentRound(null);
-      setTimeLeft(null);
-    });
+    // Keep player in /lobby if game has ended
+    const handleGameEnded = () => {      
+      toastWarning("Game Is Ended");
+      navigate("/lobby", { replace: true });
+    };
+    socket.once("gameEnded", handleGameEnded);
 
     socket.on("leftTeam", (res) => {
       if (!res?.ok) console.warn("leftTeam failed", res?.error);
@@ -302,7 +303,7 @@ const Lobby = () => {
       socket.off("kicked");
       socket.off("roundStarted");
       socket.off("startTimer");
-      socket.off("gameEnded");
+      socket.off("gameEnded", handleGameEnded);
       socket.off("leftTeam");
       socket.off("startGameError");
       socket.off("hostLeftOthers");

--- a/client/src/pages/lobby.js
+++ b/client/src/pages/lobby.js
@@ -242,10 +242,16 @@ const Lobby = () => {
 
     // Keep player in /lobby if game has ended
     const handleGameEnded = () => {      
-      toastWarning("Game Is Ended");
+      toastWarning("Game is over!");
       navigate("/lobby", { replace: true });
     };
     socket.once("gameEnded", handleGameEnded);
+
+    // Redirect player to /play/roomId
+    socket.once("gameInProgress", (data) => {
+      toastWarning("Game in progress. Joining as spectator.");
+      navigate(`/play/${data.roomId}`);
+    });
 
     socket.on("leftTeam", (res) => {
       if (!res?.ok) console.warn("leftTeam failed", res?.error);
@@ -309,6 +315,7 @@ const Lobby = () => {
       socket.off("hostLeftOthers");
       socket.off("hostDisconnectedOthers");
       socket.off("playerLeftLobby");
+      socket.off("gameInProgress");
     };
   }, [roomId, myUserId, myDisplayName, navigate]);
 

--- a/client/src/pages/lobby.js
+++ b/client/src/pages/lobby.js
@@ -163,11 +163,10 @@ const Lobby = () => {
     });
 
     // Keep player in /lobby if game has ended
-    const handleGameEnded = () => {      
+    socket.once("gameEnded", () => {
       toastWarning("Game is over!");
       navigate("/lobby", { replace: true });
-    };
-    socket.once("gameEnded", handleGameEnded);
+    });
 
     // Redirect player to /play/roomId
     socket.once("gameInProgress", (data) => {
@@ -231,7 +230,7 @@ const Lobby = () => {
       socket.off("kicked");
       socket.off("roundStarted");
       socket.off("startTimer");
-      socket.off("gameEnded", handleGameEnded);
+      socket.off("gameEnded");
       socket.off("leftTeam");
       socket.off("startGameError");
       socket.off("hostLeftOthers");

--- a/client/src/pages/play.js
+++ b/client/src/pages/play.js
@@ -191,6 +191,12 @@ const Play = () => {
     };
     socket.on("lobbyUsers", onLobbyUsers);
 
+    // Navigate to /lobby/code if the game not started
+    socket.once("newGame", (data) => {
+      toastWarning("Game is not started! Navigating to the lobby");
+      navigate(`/lobby/${data.roomId}`, { replace: true })
+    });
+
     const onProfileUpdated = ({
       userId,
       displayName,
@@ -475,6 +481,7 @@ const Play = () => {
       socket.off("playerDisconnected");
       socket.off("playerReconnected");
       socket.off("lobbyUsers", onLobbyUsers);
+      socket.off("newGame");
       socket.off("profileUpdated", onProfileUpdated);
       socket.off("gameState");
       socket.off("updatePlayers");

--- a/server/game/gameSessionManager.js
+++ b/server/game/gameSessionManager.js
@@ -75,6 +75,7 @@ class GameSessionManager {
       currentFlashcard: null,
       canvasData: null,
       // guesses are tracked per-player (p.remainingGuesses)
+      gameEnded: false // flag to indicate if game has ended (after final round)
     });
 
     // init scores
@@ -218,7 +219,10 @@ class GameSessionManager {
 
     // End game when if reached total rounds and last drawer was Blue team
     if (lastDrawer.team === "Blue" 
-        && session.currentRound >= session.totalRounds) return null;
+        && session.currentRound >= session.totalRounds){
+          session.gameEnded = true; // Mark game as ended
+          return null;
+        } 
 
     // Round number only increments after Blue team's turn, as Red always starts first
     if (lastDrawer.team === "Blue") {

--- a/server/game/gameSocket.js
+++ b/server/game/gameSocket.js
@@ -22,12 +22,14 @@ function createGameSocket(io) {
       const session = gameSessionManager.getSession(roomId);
       if (session) {
 
-          // If the game has already ended, send the final scores without rejoining
+          // If the game is ended, send the final scores without rejoining
           if (session.gameEnded) {
           socket.emit("gameEnded", { 
             finalPlayers: gameSessionManager.getPlayersWithScores(roomId)});
           return; 
-        }
+          } else {
+            socket.emit("gameInProgress", { roomId });
+          }
 
         const reconnected = gameSessionManager.markPlayerReconnected(
           roomId,

--- a/server/game/gameSocket.js
+++ b/server/game/gameSocket.js
@@ -71,6 +71,9 @@ function createGameSocket(io) {
           });
         }
       }
+      else {
+        socket.emit("newGame", { roomId:roomId });
+      }
     });
 
     socket.on("getGameState", ({ roomId }) => {

--- a/server/game/gameSocket.js
+++ b/server/game/gameSocket.js
@@ -51,6 +51,7 @@ function createGameSocket(io) {
             scores: session.scores,
             canvasData: canvasData,
             remainingGuesses: myRemainingGuesses,
+            gameEnded: session.gameEnded, // get game status
           });
 
           // Notify others that player reconnected

--- a/server/game/gameSocket.js
+++ b/server/game/gameSocket.js
@@ -21,6 +21,14 @@ function createGameSocket(io) {
       // Check if this user is reconnecting to an active game
       const session = gameSessionManager.getSession(roomId);
       if (session) {
+
+          // If the game has already ended, send the final scores without rejoining
+          if (session.gameEnded) {
+          socket.emit("gameEnded", { 
+            finalPlayers: gameSessionManager.getPlayersWithScores(roomId)});
+          return; 
+        }
+
         const reconnected = gameSessionManager.markPlayerReconnected(
           roomId,
           userId,


### PR DESCRIPTION
**Enter room with room code**
Existing code + game not start - join the lobby 
Existing code + game started - rejoin the game or (waring + join as spectator)
Existing code + game ended - warning + stay in home page

**Access /play/code**
Existing code + game not start - join the lobby 
Existing code + game started - rejoin the game or join as spectator
Existing code + game ended - navigate to leaderboard 

**Solution:**
1. Added gameEnded in gameSession with default value false. Updated value to true when game ended 
2. Added condition if (session.gameEnded) in registerLobby to emit gameEnded or gameInProgress
3. Added gameEnded and gameInProgress listener in lobby.js