### PR TITLE
fix: game lobby and session are deleted upon navigation to /end

### DIFF
--- a/client/src/pages/play.js
+++ b/client/src/pages/play.js
@@ -34,6 +34,7 @@ const Play = () => {
   const canvasRef = useRef(null);
   const playersRef = useRef([]); // holds freshest players for end screen
   const profilesRef = useRef({});
+  const hostRef = useRef(false);
   const { roomId } = useParams();
   const navigate = useNavigate(); // for /end navigation
 
@@ -542,6 +543,9 @@ const Play = () => {
 
       setTimeout(() => {
         setRoundResult(null);
+        if (hostRef.current) {
+          socket.emit("deleteRoom", { roomId });
+        }
         navigate("/end", { state: { players: withAvatars } });
       }, 1200);
     });
@@ -572,6 +576,10 @@ const Play = () => {
 
   const isHost = currentUserId === hostData?.hostId;
 
+  useEffect(() => {
+    hostRef.current = isHost;
+  }, [isHost]);
+  
   // team lists
   const redTeam = players.filter((p) => p.team === "Red");
   const blueTeam = players.filter((p) => p.team === "Blue");

--- a/server/backend/lobbyManager.js
+++ b/server/backend/lobbyManager.js
@@ -480,6 +480,13 @@ function createLobbyManager(io, UserModel) {
 
       console.log("❌ Socket disconnected:", socket.id);
     });
+
+    socket.on("deleteRoom", ({ roomId }) => {
+      if (rooms[roomId]) {
+        delete rooms[roomId];
+        console.log(`[Lobby] Deleted room ${roomId}`);
+      }
+    });
   });
 
   return { findSocketByUserId, rooms };

--- a/server/game/gameSessionManager.js
+++ b/server/game/gameSessionManager.js
@@ -583,6 +583,15 @@ class GameSessionManager {
     const session = this.sessions.get(gameId);
     return session?.canvasData || null;
   }
+
+  deleteSession(gameId) {
+    if (this.sessions.has(gameId)) {
+      this.sessions.delete(gameId);
+      console.log(`[Session] Deleted session ${gameId}`);
+      return true;
+    }
+    return false;
+  }
 }
 
 module.exports = new GameSessionManager();

--- a/server/game/gameSocket.js
+++ b/server/game/gameSocket.js
@@ -297,6 +297,11 @@ function createGameSocket(io) {
         io.to(roomId).emit("roomPlayers", { players: session.players });
     });
 
+    socket.on("deleteRoom", ({ roomId }) => {
+      console.log(`[socket] deleteRoom requested for: ${roomId}`);
+      gameSessionManager.deleteSession(roomId);
+    });
+
     // REPLACE the empty disconnect handler with this:
     socket.on("disconnect", (reason) => {
       console.log(


### PR DESCRIPTION
this fixes the issue where navigating to a previously finished game causes players to appear in newly created games

<img width="1913" height="1042" alt="image" src="https://github.com/user-attachments/assets/bb0fdc7b-68d5-4a3d-afad-1222131e7957" />
