### PR TITLE
Fixed: Player was skipped if kick someone before the player.

### DIFF
--- a/server/game/gameSessionManager.js
+++ b/server/game/gameSessionManager.js
@@ -79,6 +79,8 @@ class GameSessionManager extends EventEmitter {
       currentRound: 1, // Round number should be starts from 1 
       totalRounds,
       currentPlayerIndex: firstDrawerIndex,
+      redTeamRound: 1, // Indicater the n-th drawer of red team
+      blueTeamRound: 1, // Indicater the n-th drawer of blue team
       timer,
       difficulty,
       guesses: Number(guesses) || 5, // Guesses config with default value 3
@@ -268,6 +270,8 @@ class GameSessionManager extends EventEmitter {
         roundNumber: session.currentRound
       });
 
+      session.redTeamRound++;
+      session.blueTeamRound++;
       session.currentRound++;
     }
 
@@ -280,6 +284,8 @@ class GameSessionManager extends EventEmitter {
     return {
       currentRound: session.currentRound,
       currentPlayer: session.players[session.currentPlayerIndex],
+      redTeamRound: session.redTeamRound,
+      blueTeamRound: session.blueTeamRound,
       timer: session.timer,
       difficulty: session.difficulty,
     };
@@ -290,6 +296,8 @@ class GameSessionManager extends EventEmitter {
   _getNextDrawerIndex(session, lastDrawer) {
     // Next drawer should be from the opposite team of last drawer
     const targetTeam = (lastDrawer && lastDrawer.team === "Blue") ? "Red" : "Blue";
+    // Get the teamRound to be updated
+    const targetTeamRound = targetTeam === "Red" ? "redTeamRound" : "blueTeamRound";
 
     // Find all players and their indexes in the target team
     const targetTeamMembers = session.players
@@ -299,8 +307,8 @@ class GameSessionManager extends EventEmitter {
 
     if (targetTeamMembers.length === 0) return -1;
 
-    // Find the next drawer index based on current round number, ensuring it cycles through team members
-    const nextDrawerIndex = (session.currentRound - 1) % targetTeamMembers.length;
+    // Find the next drawer index based on teamRound number, ensuring it cycles through team members
+    const nextDrawerIndex = (session[targetTeamRound] - 1) % targetTeamMembers.length;
 
     return targetTeamMembers[nextDrawerIndex];
   }
@@ -546,6 +554,11 @@ class GameSessionManager extends EventEmitter {
 
     const isCurrentDrawer = session.currentPlayerIndex === playerIndex;
     const kickedPlayer = session.players[playerIndex];
+    // Get the teamRound to be updated
+    const kickedTeamRound = kickedPlayer.team === "Red" ? "redTeamRound" : "blueTeamRound";
+    // Get kickedPlayer's index in team
+    const kickedPlayerTeamIndex = session.players.filter(p => p.team === kickedPlayer.team).findIndex(p => p === kickedPlayer);
+    const teamSizeBefore = session.players.filter(p => p.team === kickedPlayer.team).length;
 
     // Remove player
     session.players.splice(playerIndex, 1);
@@ -558,6 +571,12 @@ class GameSessionManager extends EventEmitter {
     // then the current player index should be decremented by 1
     if (playerIndex < session.currentPlayerIndex) {
       session.currentPlayerIndex--;
+    }
+
+    // If the kicked player's index is less equal than the current team player in team, 
+    // then the current teamRound should be decremented by 1
+    if (kickedPlayerTeamIndex <= session[kickedTeamRound] % teamSizeBefore ) {
+      session[kickedTeamRound]--;
     }
     // If the kicked player index is outside of the array length,
     // set current player index back to 0 


### PR DESCRIPTION
1.Added redTeamRound and blueTeamRound in createSession 
2.Take teamRound as references when deciding next drawer 
3.Decremented teamRound when kicking player before currentPlayer in team